### PR TITLE
Fix samplerate -fPIC error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ else ()
     set (LIBSAMPLERATE_EXAMPLES OFF CACHE BOOL "")
 
     add_subdirectory (vendor/libsamplerate)
-
+    target_compile_options (samplerate PRIVATE -fPIC)
     include_directories (vendor/libsamplerate/include)
 endif ()
 


### PR DESCRIPTION
I had to add this to get it to compile. sndfile already had it set.

```
System:
  Host: lavender Kernel: 7.1.7-200.fc44.x86_64 arch: x86_64 bits: 64
  Desktop: GNOME v: 50.4 Distro: Fedora Linux 44 (Cinnamon)
``` 

